### PR TITLE
Correctly require TYPO3 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"description": "Make it possible to configure the default upload folder for a certain TCA column",
 	"license": ["GPL-2.0+"],
 	"require": {
-		"typo3/cms-core": ">=7.6.4 || >=8.0 || >= 9.5"
+		"typo3/cms-core": "^7.6.4 || ^8.0 || ^9.5"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
Previously any TYPO3 version >=7.6.4 was allowed including TYPO3v10 and any future TYPO3 version which would ever exist.