### PR TITLE
Fix file selection in RTE

### DIFF
--- a/Classes/Hooks/DefaultUploadFolder.php
+++ b/Classes/Hooks/DefaultUploadFolder.php
@@ -27,11 +27,12 @@ class DefaultUploadFolder
      */
     public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication):Folder
     {
+        $rteParameters = $_GET['P'] ?? [];
         /** @var Folder $uploadFolder */
         $uploadFolder = $params['uploadFolder'];
-        $table = $params['table'];
-        $field = $params['field'];
-        $pid = $params['pid'] ?? abs(array_keys($_GET['edit'][$table])[0]);
+        $table = $params['table'] ?? $rteParameters['table'];
+        $field = $params['field'] ?? $rteParameters['fieldName'];
+        $pid = $params['pid'] ?? $rteParameters['pid'] ?? 0;
         $pageTs = BackendUtility::getPagesTSconfig($pid);
 
         $subFolder = $pageTs['default_upload_folders.'][$table . '.'][$field] ?? $pageTs['default_upload_folders.'][$table] ?? '';


### PR DESCRIPTION
In case a file should be linked from the RTE, there are no basic parameters. Thus fall back to the RTE-specific parameters provided via GET.

See [TYPO3\CMS\RteCKEditor\Controller\BrowseLinksController::getUrlParameters()](https://github.com/TYPO3/TYPO3.CMS/blob/10.4/typo3/sysext/rte_ckeditor/Classes/Controller/BrowseLinksController.php#L528)
And #19