### PR TITLE
[FEATURE] Reintroduce configuration via User TSconfig

### DIFF
--- a/Classes/Hooks/DefaultUploadFolder.php
+++ b/Classes/Hooks/DefaultUploadFolder.php
@@ -25,7 +25,7 @@ class DefaultUploadFolder
      * @param BackendUserAuthentication $backendUserAuthentication
      * @return Folder
      */
-    public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication)
+    public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication):Folder
     {
         $rteParameters = $_GET['P'] ?? [];
         /** @var Folder $uploadFolder */


### PR DESCRIPTION
Commit adef7ee9b83c9c411a1f7dd2c9bc89ac63a9564f removed upload folder configuration via User TSconfig. This was unnecessary because the used method `TYPO3\CMS\core\Authentication\BackendUserAuthentication->getTSConfig()` is not deprecated in TYPO3 10: [Deprecation: #84993 - Deprecate some TSconfig related methods](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.3/Deprecation-84993-DeprecateSomeTSconfigRelatedMethods.html)
