### PR TITLE
[TASK] Add upload folder check

### DIFF
--- a/Classes/Hooks/DefaultUploadFolder.php
+++ b/Classes/Hooks/DefaultUploadFolder.php
@@ -23,10 +23,13 @@ class DefaultUploadFolder
      *
      * @param array $params
      * @param BackendUserAuthentication $backendUserAuthentication
-     * @return Folder
+     * @return Folder|null
      */
-    public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication):Folder
+    public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication):?Folder
     {
+        if (!($params['uploadFolder'] instanceof Folder)) {
+            return null;
+        }
         $rteParameters = $_GET['P'] ?? [];
         /** @var Folder $uploadFolder */
         $uploadFolder = $params['uploadFolder'];


### PR DESCRIPTION
If a backend user has no file mount at all and therefore no permission to access any folder it makes no sense to set a default upload folder. In such cases parameter uploadFolder is the empty string or null and method getDefaultUploadFolder should return immediately.