### PR TITLE
[BUGFIX] Remove Folder type hint since $uploadFolder can also be null or string

### DIFF
--- a/Classes/Hooks/DefaultUploadFolder.php
+++ b/Classes/Hooks/DefaultUploadFolder.php
@@ -23,9 +23,9 @@ class DefaultUploadFolder
      *
      * @param array $params
      * @param BackendUserAuthentication $backendUserAuthentication
-     * @return Folder
+     * @return Folder|string|null
      */
-    public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication):Folder
+    public function getDefaultUploadFolder($params, BackendUserAuthentication $backendUserAuthentication)
     {
         $rteParameters = $_GET['P'] ?? [];
         /** @var Folder $uploadFolder */


### PR DESCRIPTION
The value obtained from `$params['uploadFolder']` can also be a string or null looking at the TYPO3 source code in `BackendUserAuthentication.php`:

```php
    public function getDefaultUploadFolder($pid = null, $table = null, $field = null)
    {
        $uploadFolder = $this->getTSConfig()['options.']['defaultUploadFolder'] ?? '';
        
        if ($uploadFolder) {
            try {
                $uploadFolder = GeneralUtility::makeInstance(ResourceFactory::class)->getFolderObjectFromCombinedIdentifier($uploadFolder);
            } catch (Exception\FolderDoesNotExistException $e) {
                $uploadFolder = null;
            }
        }
        
        // [...]

        foreach ($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauthgroup.php']['getDefaultUploadFolder'] ?? [] as $_funcRef) {
            $_params = [
                'uploadFolder' => $uploadFolder,
                'pid' => $pid,
                'table' => $table,
                'field' => $field,
            ];
            $uploadFolder = GeneralUtility::callUserFunction($_funcRef, $_params, $this);
        }

        if ($uploadFolder instanceof Folder) {
            return $uploadFolder;
        }

        return false;
    }
```

Thus enforcing the type hint `Folder` can lead to errors. We discovered this issue when users only have access to a subfolder of `fileadmin/user_upload`, e.g. `fileadmin/user_upload/xy` and try to edit a page.